### PR TITLE
Remove silent option since it's the default in symfony/console 7.2

### DIFF
--- a/src/Supervisor/Console/RestartHorizon.php
+++ b/src/Supervisor/Console/RestartHorizon.php
@@ -13,7 +13,7 @@ class RestartHorizon extends Command
      *
      * @var string
      */
-    protected $signature = 'supervisor:check {--r|resume-if-paused} {--s|silent} {--p|php-path=}';
+    protected $signature = 'supervisor:check {--r|resume-if-paused} {--p|php-path=}';
 
     /**
      * The console command description.


### PR DESCRIPTION
There was [a Breaking Change in symfony/console 7.2](https://github.com/symfony/symfony/blob/7.2/src/Symfony/Component/Console/CHANGELOG.md#72) where `--silent` option is now added by default to all commands.

It causes the following error `An option named "silent" already exists.`